### PR TITLE
add a small value to np.log to prevent nan

### DIFF
--- a/binary_classification.py
+++ b/binary_classification.py
@@ -75,7 +75,7 @@ class l_layer_neural_network:
         return AL
 
     def compute_cost(self,AL):
-        cost = -1*(np.sum(np.multiply(self.Y,np.log(AL)) + np.multiply(1-self.Y,np.log(1-AL))))/self.m
+        cost = -1*(np.sum(np.multiply(self.Y,np.log(AL+1e-5)) + np.multiply(1-self.Y,np.log(1-AL+1e-5))))/self.m
         cost = np.squeeze(cost)
         assert(cost.shape == ())
         return cost


### PR DESCRIPTION
@Rishav159 
I think the reason why you got nan was because of the cost function. When np.log(0) happens, you will get nan values. The way that I prevent this situation from happening is simply add a very small value `1e-5`. Therefore, the cost function becomes 
`cost = -1*(np.sum(np.multiply(self.Y,np.log(AL+1e-5)) + np.multiply(1-self.Y,np.log(1-AL+1e-5))))/self.m` 
Please let me know if it helps. #1